### PR TITLE
이용약관 저장, 프로젝트 관리 부분 수정

### DIFF
--- a/src/main/java/Idea/Idea_Hive/member/entity/Member.java
+++ b/src/main/java/Idea/Idea_Hive/member/entity/Member.java
@@ -63,9 +63,13 @@ public class Member {
 
     private String type; // sns 연동 유형
 
-    private boolean isVerified;
-
     private String profileUrl;
+
+    private boolean isServiceAgreed;
+
+    private boolean isPrivacyAgreed;
+
+    private boolean isMarketingAgreed;
 
 
 
@@ -108,7 +112,9 @@ public class Member {
     @Builder
     public Member(final String name, final String email,
                   final String password, final String job,
-                  final String type, final Integer career) {
+                  final String type, final Integer career,
+                  final boolean isServiceAgreed, final boolean isPrivacyAgreed,
+                  final boolean isMarketingAgreed) {
         this.name = name;
         this.email = email;
         this.password = password;
@@ -117,5 +123,8 @@ public class Member {
         this.career = career;
         this.createdDate = LocalDateTime.now();
         this.isDeleted = false;
+        this.isServiceAgreed = isServiceAgreed;
+        this.isPrivacyAgreed = isPrivacyAgreed;
+        this.isMarketingAgreed = isMarketingAgreed;
     }
 }

--- a/src/main/java/Idea/Idea_Hive/member/entity/dto/request/SignUpRequest.java
+++ b/src/main/java/Idea/Idea_Hive/member/entity/dto/request/SignUpRequest.java
@@ -7,6 +7,9 @@ import java.util.List;
 public record SignUpRequest(
         String email,
         String name,
-        String password
+        String password,
+        boolean isServiceAgreed,
+        boolean isPrivacyAgreed,
+        boolean isMarketingAgreed
 ) {
 }

--- a/src/main/java/Idea/Idea_Hive/member/entity/dto/response/ProjectMemberInfoResponse.java
+++ b/src/main/java/Idea/Idea_Hive/member/entity/dto/response/ProjectMemberInfoResponse.java
@@ -1,17 +1,13 @@
 package Idea.Idea_Hive.member.entity.dto.response;
 
 import Idea.Idea_Hive.member.entity.Member;
-import Idea.Idea_Hive.member.entity.MemberSkillStack;
 import Idea.Idea_Hive.project.entity.Role;
-import Idea.Idea_Hive.skillstack.entity.SkillStack;
 import Idea.Idea_Hive.skillstack.entity.dto.SkillStackVO;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-public record MemberInfoResponse(
+public record ProjectMemberInfoResponse(
         Long id,
         String name,
         String email,
@@ -25,16 +21,22 @@ public record MemberInfoResponse(
         Boolean isDeleted,
         Boolean isServiceAgreed,
         Boolean isPrivacyAgreed,
-        Boolean isMarketingAgreed
+        Boolean isMarketingAgreed,
+        Role projectRole
 ) {
-
-    public static MemberInfoResponse from(Member member) {
+    public static ProjectMemberInfoResponse from(Member member, Long projectId) {
 
         List<SkillStackVO> skillStacks = member.getMemberSkillStacks().stream()
                 .map(ms -> SkillStackVO.from(ms.getSkillstack()))
                 .toList();
 
-        return new MemberInfoResponse(
+        Role projectRole = member.getProjectMembers().stream()
+                .filter(pm -> pm.getProject().getId().equals(projectId))
+                .findFirst()
+                .map(pm -> pm.getRole())
+                .orElse(null);
+
+        return new ProjectMemberInfoResponse(
                 member.getId(),
                 member.getName(),
                 member.getEmail(),
@@ -48,7 +50,8 @@ public record MemberInfoResponse(
                 member.getIsDeleted(),
                 member.isServiceAgreed(),
                 member.isPrivacyAgreed(),
-                member.isMarketingAgreed()
+                member.isMarketingAgreed(),
+                projectRole
         );
     }
 }

--- a/src/main/java/Idea/Idea_Hive/member/service/MemberService.java
+++ b/src/main/java/Idea/Idea_Hive/member/service/MemberService.java
@@ -50,6 +50,9 @@ public class MemberService {
                 .name(request.name())
                 .password(hashedPassword)
                 .type("email")
+                .isServiceAgreed(request.isServiceAgreed())
+                .isPrivacyAgreed(request.isPrivacyAgreed())
+                .isMarketingAgreed(request.isMarketingAgreed())
                 .build();
 
         Member saved = memberRepository.save(member);

--- a/src/main/java/Idea/Idea_Hive/project/controller/ProjectManageController.java
+++ b/src/main/java/Idea/Idea_Hive/project/controller/ProjectManageController.java
@@ -3,6 +3,7 @@ package Idea.Idea_Hive.project.controller;
 import Idea.Idea_Hive.auth.service.AuthService;
 import Idea.Idea_Hive.member.entity.Member;
 import Idea.Idea_Hive.member.entity.dto.response.MemberInfoResponse;
+import Idea.Idea_Hive.member.entity.dto.response.ProjectMemberInfoResponse;
 import Idea.Idea_Hive.member.entity.repository.MemberRepository;
 import Idea.Idea_Hive.project.dto.request.ProjectLeaveRequest;
 import Idea.Idea_Hive.project.dto.request.ProjectSubmitRequest;
@@ -87,7 +88,7 @@ public class ProjectManageController {
 
     @Operation(summary="프로젝트 멤버 조회 API")
     @GetMapping("/members")
-    public ResponseEntity<List<MemberInfoResponse>> getProjectMemebers(@RequestParam("id") Long id) {
+    public ResponseEntity<List<ProjectMemberInfoResponse>> getProjectMemebers(@RequestParam("id") Long id) {
         return ResponseEntity.ok(
                 projectManageService.getMembersByProjectId(id)
         );

--- a/src/main/java/Idea/Idea_Hive/project/dto/response/MyPageProjectListResponse.java
+++ b/src/main/java/Idea/Idea_Hive/project/dto/response/MyPageProjectListResponse.java
@@ -17,6 +17,7 @@ public record MyPageProjectListResponse(
         int pageSize
 ) {
     public static MyPageProjectListResponse of(Page<Project> projectPage) {
+
         Map<ProjectStatus, List<ProjectManageResponse>> projectMap = projectPage.getContent().stream()
                 .map(ProjectManageResponse::from)
                 .collect(Collectors.groupingBy(

--- a/src/main/java/Idea/Idea_Hive/project/entity/repository/manage/ProjectManageRepositoryCustomImpl.java
+++ b/src/main/java/Idea/Idea_Hive/project/entity/repository/manage/ProjectManageRepositoryCustomImpl.java
@@ -79,7 +79,10 @@ public class ProjectManageRepositoryCustomImpl implements ProjectManageRepositor
                 .select(project)
                 .from(project)
                 .join(project.projectMembers, projectMember)
-                .where(projectMember.member.id.eq(memberId))
+                .where(
+                        projectMember.member.id.eq(memberId),ㅔ
+                        project.status.ne(ProjectStatus.RECRUITING) // RECRUITING이 아닌 프로젝트만
+                )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(project.createdDate.desc())
@@ -90,7 +93,10 @@ public class ProjectManageRepositoryCustomImpl implements ProjectManageRepositor
                 .select(project.count())
                 .from(project)
                 .join(project.projectMembers, projectMember)
-                .where(projectMember.member.id.eq(memberId))
+                .where(
+                        projectMember.member.id.eq(memberId),
+                        project.status.ne(ProjectStatus.RECRUITING) // RECRUITING이 아닌 프로젝트만
+                )
                 .fetchOne()
         ).orElse(0L);
 

--- a/src/main/java/Idea/Idea_Hive/project/service/ProjectManageService.java
+++ b/src/main/java/Idea/Idea_Hive/project/service/ProjectManageService.java
@@ -3,6 +3,7 @@ package Idea.Idea_Hive.project.service;
 import Idea.Idea_Hive.exception.handler.custom.InvalidProjectManageException;
 import Idea.Idea_Hive.member.entity.Member;
 import Idea.Idea_Hive.member.entity.dto.response.MemberInfoResponse;
+import Idea.Idea_Hive.member.entity.dto.response.ProjectMemberInfoResponse;
 import Idea.Idea_Hive.member.entity.repository.MemberRepository;
 import Idea.Idea_Hive.project.dto.request.ProjectLeaveRequest;
 import Idea.Idea_Hive.project.dto.response.MyPageProjectListResponse;
@@ -71,9 +72,9 @@ public class ProjectManageService {
         return MyPageProjectListResponse.of(projects);
     }
 
-    public List<MemberInfoResponse> getMembersByProjectId(Long projectId) {
+    public List<ProjectMemberInfoResponse> getMembersByProjectId(Long projectId) {
         return projectManageRepository.findMemberByProjectId(projectId)
-                .stream().map(MemberInfoResponse::from)
+                .stream().map(member -> ProjectMemberInfoResponse.from(member, projectId))
                 .toList();
     }
 

--- a/src/main/java/Idea/Idea_Hive/task/dto/request/UpdateTaskDueDateRequest.java
+++ b/src/main/java/Idea/Idea_Hive/task/dto/request/UpdateTaskDueDateRequest.java
@@ -1,9 +1,9 @@
 package Idea.Idea_Hive.task.dto.request;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 public record UpdateTaskDueDateRequest(
         Long taskId,
-        Date dueDate
+        LocalDateTime dueDate
 ) {
 }

--- a/src/main/java/Idea/Idea_Hive/task/dto/response/TaskResponse.java
+++ b/src/main/java/Idea/Idea_Hive/task/dto/response/TaskResponse.java
@@ -3,6 +3,7 @@ package Idea.Idea_Hive.task.dto.response;
 import Idea.Idea_Hive.task.entity.Task;
 import Idea.Idea_Hive.task.entity.TaskType;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 public record TaskResponse(
@@ -14,7 +15,7 @@ public record TaskResponse(
         String attachedLink,
         String filePath,
         String pic, // 담당자 이름
-        Date dueDate,
+        LocalDateTime dueDate,
         Date uploadDate,
         Long picId
 ) {

--- a/src/main/java/Idea/Idea_Hive/task/entity/Task.java
+++ b/src/main/java/Idea/Idea_Hive/task/entity/Task.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Entity
@@ -41,7 +42,7 @@ public class Task {
 
     // 마감 기한
     @Setter
-    private Date dueDate;
+    private LocalDateTime dueDate;
 
     // 제출 시간
     private Date uploadDate;
@@ -55,7 +56,7 @@ public class Task {
     private Member member;
 
     @Builder
-    public Task(Boolean isRequired, Boolean isSubmitted, String title, TaskType taskType, String filePath, Date dueDate,
+    public Task(Boolean isRequired, Boolean isSubmitted, String title, TaskType taskType, String filePath, LocalDateTime dueDate,
                 String attachedLink) {
         this.isRequired = isRequired;
         this.isSubmitted = isSubmitted;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,7 +24,7 @@ spring:
           
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true
@@ -35,7 +35,7 @@ spring:
 
   sql:
     init:
-      mode: always # ddl-auto가 update 일때는 never, create일 때는 always로 설정해야 skillstack 테이블에 데이터가 중복으로 들어가지 않음
+      mode: never # ddl-auto가 update 일때는 never, create일 때는 always로 설정해야 skillstack 테이블에 데이터가 중복으로 들어가지 않음
 
   security:
     oauth2:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,7 +24,7 @@ spring:
           
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true
@@ -35,7 +35,7 @@ spring:
 
   sql:
     init:
-      mode: never # ddl-auto가 update 일때는 never, create일 때는 always로 설정해야 skillstack 테이블에 데이터가 중복으로 들어가지 않음
+      mode: always # ddl-auto가 update 일때는 never, create일 때는 always로 설정해야 skillstack 테이블에 데이터가 중복으로 들어가지 않음
 
   security:
     oauth2:


### PR DESCRIPTION
## ✍🏻 변경사항

1. 회원가입 시, 이용약관 동의 저장 → 필수 값 2개, 선택 값 1개 → Member Entity도 수정 필요
- Member 테이블에 컬럼 추가
1) 서비스 이용약관 동의 여부(isServiceAgreed)
2) 개인정보 수집 및 이용 동의 여부(isPrivacyAgreed)
3) 마케팅 수신 동의 여부(isMarketingAgreed)
- Member 테이블에서 동의 여부(isVerified) 컬럼 삭제
- 이메일 회원 가입 시 이용약관 동의 여부 값 저장

2. 프로젝트 멤버 조회 API 수정
- 프론트에서 멤버의 role도 같이 return해달라는 요청이 있어서 1번 처리하면서 같이 수정하였습니다

3.   프로젝트 관리에서 과제 마감기한 설정 할 때, 표준 시간 수정
4. 내 모든 프로젝트 조회 시 모집중인 프로젝트 제외
